### PR TITLE
Update Zenodo upload example to include all UV data files

### DIFF
--- a/examples_undoc/zenodo_upload.py
+++ b/examples_undoc/zenodo_upload.py
@@ -1,9 +1,8 @@
-"""Upload a file from the examples directory to Zenodo
-------------------------------------------------------
+"""Upload the UV example files to Zenodo
+-------------------------------------
 
-This example demonstrates how to locate an example data file, ensure it is
-present locally, and then upload it to Zenodo.  The file we upload is the same
-one used in :mod:`examples.UV.Cary_simple`.
+This example demonstrates how to locate each data file used in the
+:mod:`examples.UV` package and upload them all to the same Zenodo deposition.
 
 To run this script you must create a personal access token on the Zenodo
 website (with ``deposit:write`` scope).  Save the token in a file and reference
@@ -12,18 +11,29 @@ it from the ``[zenodo]`` section of ``~/.pyspecdata``::
     [zenodo]
     token_file = /path/to/zenodo.token
 
-The script will create a new deposition record automatically and then upload
-the file to that deposition.
+A new deposition record will be created automatically for the first file and the
+remaining files will be uploaded to that same deposition.
 """
 
 from pyspecdata import search_filename, zenodo_upload
 
-# locate the data using the same search string as
-# :mod:`examples.UV.Cary_simple`
-local_path = search_filename(
-    "T177R1a_pR_210615",
-    exp_type="UV_Vis/proteorhodopsin",
-    unique=True,
-)
+# list of (search string, exp_type) pairs for all UV examples
+files_to_upload = [
+    ("T177R1a_pR_210615", "UV_Vis/proteorhodopsin"),
+    ("221110_BSAexerciseWK_0p07-0percentBSAcalibration.BSW", "UV_Vis/BSA_Exercise"),
+    ("200703_Ellman_before_SL.DSW", "UV_Vis/Ellmans_Assay"),
+    ("Ras_Stability4", "UV_Vis/Ras_stability/200803_RT"),
+]
 
-zenodo_upload(local_path, title="UV-Vis documentation examples for pySpecdata")
+deposition_id = None
+for search_str, exp_type in files_to_upload:
+    local_path = search_filename(search_str, exp_type=exp_type, unique=True)
+    if deposition_id is None:
+        deposition_id = zenodo_upload(
+            local_path,
+            title="UV-Vis documentation examples for pySpecdata",
+        )
+    else:
+        zenodo_upload(local_path, deposition_id=deposition_id)
+
+print("View deposition at https://zenodo.org/uploads/" + str(deposition_id))


### PR DESCRIPTION
## Summary
- update `zenodo_upload.py` example to gather all UV example datasets
- upload all UV datasets to a single Zenodo deposition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a2c5500c832baf556aff302c6306