### PR TITLE
Update Zenodo upload example to pre-reserve DOI

### DIFF
--- a/examples_undoc/zenodo_upload.py
+++ b/examples_undoc/zenodo_upload.py
@@ -1,9 +1,10 @@
-"""Upload a file from the examples directory to Zenodo
-------------------------------------------------------
+"""Upload the UV example files to Zenodo
+-------------------------------------
 
-This example demonstrates how to locate an example data file, ensure it is
-present locally, and then upload it to Zenodo.  The file we upload is the same
-one used in :mod:`examples.UV.Cary_simple`.
+This example demonstrates how to locate each data file used in the
+:mod:`examples.UV` package and upload them all to the same Zenodo deposition.
+The deposition reserves a DOI, sets the resource type to ``dataset``, and
+marks today's date as available.
 
 To run this script you must create a personal access token on the Zenodo
 website (with ``deposit:write`` scope).  Save the token in a file and reference
@@ -12,18 +13,29 @@ it from the ``[zenodo]`` section of ``~/.pyspecdata``::
     [zenodo]
     token_file = /path/to/zenodo.token
 
-The script will create a new deposition record automatically and then upload
-the file to that deposition.
+A new deposition record will be created automatically for the first file and the
+remaining files will be uploaded to that same deposition.
 """
 
 from pyspecdata import search_filename, zenodo_upload
 
-# locate the data using the same search string as
-# :mod:`examples.UV.Cary_simple`
-local_path = search_filename(
-    "T177R1a_pR_210615",
-    exp_type="UV_Vis/proteorhodopsin",
-    unique=True,
-)
+# list of (search string, exp_type) pairs for all UV examples
+files_to_upload = [
+    ("T177R1a_pR_210615", "UV_Vis/proteorhodopsin"),
+    ("221110_BSAexerciseWK_0p07-0percentBSAcalibration.BSW", "UV_Vis/BSA_Exercise"),
+    ("200703_Ellman_before_SL.DSW", "UV_Vis/Ellmans_Assay"),
+    ("Ras_Stability4", "UV_Vis/Ras_stability/200803_RT"),
+]
 
-zenodo_upload(local_path, title="UV-Vis documentation examples for pySpecdata")
+deposition_id = None
+for search_str, exp_type in files_to_upload:
+    local_path = search_filename(search_str, exp_type=exp_type, unique=True)
+    if deposition_id is None:
+        deposition_id = zenodo_upload(
+            local_path,
+            title="UV-Vis documentation examples for pySpecdata",
+        )
+    else:
+        zenodo_upload(local_path, deposition_id=deposition_id)
+
+print("View deposition at https://zenodo.org/uploads/" + str(deposition_id))

--- a/examples_undoc/zenodo_upload.py
+++ b/examples_undoc/zenodo_upload.py
@@ -38,4 +38,4 @@ for search_str, exp_type in files_to_upload:
     else:
         zenodo_upload(local_path, deposition_id=deposition_id)
 
-print("View deposition at https://zenodo.org/uploads/" + str(deposition_id))
+print("View deposition at https://zenodo.org/deposit/" + str(deposition_id))

--- a/examples_undoc/zenodo_upload.py
+++ b/examples_undoc/zenodo_upload.py
@@ -38,4 +38,4 @@ for search_str, exp_type in files_to_upload:
     else:
         zenodo_upload(local_path, deposition_id=deposition_id)
 
-print("View deposition at https://zenodo.org/deposit/" + str(deposition_id))
+print("View deposition at https://zenodo.org/uploads/" + str(deposition_id))

--- a/examples_undoc/zenodo_upload.py
+++ b/examples_undoc/zenodo_upload.py
@@ -13,8 +13,8 @@ it from the ``[zenodo]`` section of ``~/.pyspecdata``::
     [zenodo]
     token_file = /path/to/zenodo.token
 
-A new deposition record will be created automatically for the first file and the
-remaining files will be uploaded to that same deposition.
+A new deposition record will be created automatically for the first file and
+the remaining files will be uploaded to that same deposition.
 """
 
 from pyspecdata import search_filename, zenodo_upload
@@ -22,7 +22,10 @@ from pyspecdata import search_filename, zenodo_upload
 # list of (search string, exp_type) pairs for all UV examples
 files_to_upload = [
     ("T177R1a_pR_210615", "UV_Vis/proteorhodopsin"),
-    ("221110_BSAexerciseWK_0p07-0percentBSAcalibration.BSW", "UV_Vis/BSA_Exercise"),
+    (
+        "221110_BSAexerciseWK_0p07-0percentBSAcalibration.BSW",
+        "UV_Vis/BSA_Exercise",
+    ),
     ("200703_Ellman_before_SL.DSW", "UV_Vis/Ellmans_Assay"),
     ("Ras_Stability4", "UV_Vis/Ras_stability/200803_RT"),
 ]

--- a/pyspecdata/load_files/zenodo.py
+++ b/pyspecdata/load_files/zenodo.py
@@ -66,9 +66,9 @@ def zenodo_download(deposition, searchstring, exp_type=None):
 def create_deposition(title):
     """Create a new Zenodo deposition using ``title``.
 
-    The deposition will reserve a DOI, set the resource type to
-    ``dataset``, set today's date as the publication date, and mark the
-    date type as ``Available``.
+    The deposition will pre-reserve a DOI, set the upload type to
+    ``dataset`` and mark today's date as both the publication date and the
+    availability date.
     """
 
     token = _get_token()
@@ -77,9 +77,9 @@ def create_deposition(title):
     metadata = {
         "title": title,
         "prereserve_doi": True,
-        "resource_type": {"type": "dataset"},
+        "upload_type": "dataset",
         "publication_date": today,
-        "dates": [{"start": today, "end": today, "type": "Available"}],
+        "dates": [{"date": today, "date_type": "Available"}],
     }
 
     r = requests.post(

--- a/pyspecdata/load_files/zenodo.py
+++ b/pyspecdata/load_files/zenodo.py
@@ -76,9 +76,8 @@ def create_deposition(title):
     today = datetime.date.today().isoformat()
     metadata = {
         "title": title,
-        # set prereserve_doi but explicitly indicate we do not already have one
+        # reserve a DOI without providing an existing one
         "prereserve_doi": True,
-        "doi": None,
         "upload_type": "dataset",
         "publication_date": today,
         # ``type`` corresponds to the "Type" field on the website

--- a/pyspecdata/load_files/zenodo.py
+++ b/pyspecdata/load_files/zenodo.py
@@ -76,7 +76,9 @@ def create_deposition(title):
     today = datetime.date.today().isoformat()
     metadata = {
         "title": title,
+        # set prereserve_doi but explicitly indicate we do not already have one
         "prereserve_doi": True,
+        "doi": None,
         "upload_type": "dataset",
         "publication_date": today,
         # ``type`` corresponds to the "Type" field on the website

--- a/pyspecdata/load_files/zenodo.py
+++ b/pyspecdata/load_files/zenodo.py
@@ -1,6 +1,7 @@
 import os
 import urllib.request
 import re
+import datetime
 from ..datadir import getDATADIR, pyspec_config
 import logging
 import requests
@@ -63,15 +64,28 @@ def zenodo_download(deposition, searchstring, exp_type=None):
 
 
 def create_deposition(title):
-    """Create a new Zenodo deposition with ``title`` and return the
-    deposition identifier."""
+    """Create a new Zenodo deposition using ``title``.
+
+    The deposition will reserve a DOI, set the resource type to
+    ``dataset``, set today's date as the publication date, and mark the
+    date type as ``Available``.
+    """
 
     token = _get_token()
+
+    today = datetime.date.today().isoformat()
+    metadata = {
+        "title": title,
+        "prereserve_doi": True,
+        "resource_type": {"type": "dataset"},
+        "publication_date": today,
+        "dates": [{"start": today, "end": today, "type": "Available"}],
+    }
 
     r = requests.post(
         "https://zenodo.org/api/deposit/depositions",
         params={"access_token": token},
-        json={"metadata": {"title": title}},
+        json={"metadata": metadata},
     )
     r.raise_for_status()
     return r.json()["id"]

--- a/pyspecdata/load_files/zenodo.py
+++ b/pyspecdata/load_files/zenodo.py
@@ -79,7 +79,8 @@ def create_deposition(title):
         "prereserve_doi": True,
         "upload_type": "dataset",
         "publication_date": today,
-        "dates": [{"date": today, "date_type": "Available"}],
+        # ``type`` corresponds to the "Type" field on the website
+        "dates": [{"date": today, "type": "Available"}],
     }
 
     r = requests.post(
@@ -126,7 +127,7 @@ def zenodo_upload(local_path, title=None, deposition_id=None):
     r.raise_for_status()
     info = r.json()
     print("Uploaded", info["filename"])
-    print("View deposition at", f"https://zenodo.org/uploads/{deposition_id}")
+    print("View deposition at", f"https://zenodo.org/deposit/{deposition_id}")
 
     # record the upload in the config file
     n_uploads = int(

--- a/pyspecdata/load_files/zenodo.py
+++ b/pyspecdata/load_files/zenodo.py
@@ -88,7 +88,12 @@ def create_deposition(title):
         params={"access_token": token},
         json={"metadata": metadata},
     )
-    r.raise_for_status()
+    try:
+        r.raise_for_status()
+    except requests.HTTPError as exc:
+        msg = f"{exc}\n{r.text}"
+        logging.error("failed to create deposition: %s", msg)
+        raise requests.HTTPError(msg) from exc
     return r.json()["id"]
 
 
@@ -127,7 +132,7 @@ def zenodo_upload(local_path, title=None, deposition_id=None):
     r.raise_for_status()
     info = r.json()
     print("Uploaded", info["filename"])
-    print("View deposition at", f"https://zenodo.org/deposit/{deposition_id}")
+    print("View deposition at", f"https://zenodo.org/uploads/{deposition_id}")
 
     # record the upload in the config file
     n_uploads = int(

--- a/pyspecdata/load_files/zenodo.py
+++ b/pyspecdata/load_files/zenodo.py
@@ -80,7 +80,7 @@ def create_deposition(title):
         "upload_type": "dataset",
         "publication_date": today,
         # ``type`` corresponds to the "Type" field on the website
-        "dates": [{"date": today, "type": "Available"}],
+        "dates": [{"start": today, "end": today, "type": "Available"}],
     }
 
     r = requests.post(


### PR DESCRIPTION
## Summary
- update Zenodo upload example notes about deposition metadata
- reserve DOI and set dataset metadata when creating a deposition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a2c5500c832baf556aff302c6306