### PR TITLE
Add high-level NNLS test with compiled extension

### DIFF
--- a/examples/BRD_test.py
+++ b/examples/BRD_test.py
@@ -5,8 +5,10 @@
 for 1D BRD, adapted mainly from Venkataramanan 2002
 but checked against BRD 1981"""
 
-from pylab import *
-from pyspecdata import *
+from matplotlib.pyplot import figure, show, title, legend, axvline
+from numpy import linspace, exp, zeros, eye, logspace, r_, sqrt, pi, std
+from pylab import linalg
+from pyspecdata import nddata, init_logging, plot
 from scipy.optimize import nnls
 from numpy.random import seed
 
@@ -19,31 +21,29 @@ logT1 = nddata(r_[-4:2:100j], t1_name)
 
 mu1 = 0.5
 sigma1 = 0.3
-L_curve_l = 0.036 # read manually off of plot
+L_curve_l = 0.036  # read manually off of plot
 plot_Lcurve = True
 true_F = (
-    1
-    / np.sqrt(2 * np.pi * sigma1**2)
-    * exp(-((logT1 - mu1) ** 2) / 2 / sigma1**2)
+    1 / sqrt(2 * pi * sigma1**2) * exp(-((logT1 - mu1) ** 2) / 2 / sigma1**2)
 )
 
 
 K = 1.0 - 2 * exp(-vd_list / 10 ** (logT1))
 
 K.reorder("vd")  # make sure vd along rows
-print(shape(K))
-print(shape(true_F))
+print(K.shape)
+print(true_F.shape)
 
 M = K @ true_F  # the fake data
-print(shape(M))
+print(M.shape)
 # M.setaxis('vd',y_axis)
 M.add_noise(0.2)
 M /= 0.2  # this is key -- make sure that the noise variance is 1, for BRD
 
 # this is here to test the integrated 1D-BRD (for pyspecdata)
 print("*** *** ***")
-print(ndshape(M))
-print(ndshape(logT1))
+print(M.shape)
+print(logT1.shape)
 print("*** *** ***")
 solution = M.C.nnls(
     "vd", logT1, lambda x, y: 1 - 2 * exp(-x / 10 ** (y)), l="BRD"
@@ -62,8 +62,9 @@ def nnls_reg(K, b, val):
     return x
 
 
-# generate the A matrix, which should have form of the original kernel
-# and then an additional length corresponding to size of the data dimension, where smothing param val is placed
+# generate the A matrix, which should have form of the original kernel and then
+# an additional length corresponding to size of the data dimension, where
+# smothing param val is placed
 def A_prime(K, val):
     dimension = K.shape[1]
     A_prime = r_[K, val * eye(dimension)]
@@ -81,14 +82,13 @@ if plot_Lcurve:
             logspace(-10, 1, 25)
         ),  # adjusting the left number will adjust the right side of L-curve
     )
-    print(ndshape(x))
     # norm of the residual (data - soln)
     # norm of the solution (taken along the fit axis)
     x.run(linalg.norm, t1_name)
 
     # From L-curve
     figure()
-    axvline(x=L_curve_l, ls='--')
+    axvline(x=L_curve_l, ls="--")
     plot(x)
     # }}}
 
@@ -119,7 +119,7 @@ plot(solution, ":", label="pyspecdata-BRD")
 plot(
     solution_confirm,
     "--",
-    label=rf'manual BRD $\alpha={solution.get_prop("opt_alpha"):#0.2g}$',
+    label=rf"manual BRD $\alpha={solution.get_prop('opt_alpha'):#0.2g}$",
     alpha=0.5,
 )
 print(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,17 +7,6 @@ import numpy as np
 import os
 
 PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "pyspecdata"
-BUILD_DIR = PACKAGE_ROOT.parent / "build"
-MESON_SKIP = os.environ.get("MESONPY_EDITABLE_SKIP", "").split(os.pathsep)
-for path in (
-    BUILD_DIR,
-    BUILD_DIR / f"cp{sys.version_info.major}{sys.version_info.minor}",
-):
-    if str(path) not in MESON_SKIP:
-        MESON_SKIP.append(str(path))
-    if str(path) not in sys.path:
-        sys.path.insert(0, str(path))
-os.environ["MESONPY_EDITABLE_SKIP"] = os.pathsep.join(filter(None, MESON_SKIP))
 
 
 def load_module(name: str, *, use_real_pint: bool = False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,21 @@ import numpy as np
 import os
 
 PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "pyspecdata"
+BUILD_DIR = PACKAGE_ROOT.parent / "build"
+MESON_SKIP = os.environ.get("MESONPY_EDITABLE_SKIP", "").split(os.pathsep)
+for path in (
+    BUILD_DIR,
+    BUILD_DIR / f"cp{sys.version_info.major}{sys.version_info.minor}",
+):
+    if str(path) not in MESON_SKIP:
+        MESON_SKIP.append(str(path))
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+os.environ["MESONPY_EDITABLE_SKIP"] = os.pathsep.join(filter(None, MESON_SKIP))
 
 
 def load_module(name: str, *, use_real_pint: bool = False):
-    """Load a pyspecdata submodule without requiring compiled extensions.
+    """Load a pyspecdata submodule without requiring external packages.
 
     Parameters
     ----------
@@ -23,7 +34,6 @@ def load_module(name: str, *, use_real_pint: bool = False):
         environment without the real dependency installed.
     """
     # provide dummy replacements for optional compiled dependencies
-    sys.modules.setdefault("_nnls", types.ModuleType("_nnls"))
     sys.modules.setdefault("tables", types.ModuleType("tables"))
     sys.modules.setdefault("h5py", types.ModuleType("h5py"))
 

--- a/tests/test_highlevel_nnls.py
+++ b/tests/test_highlevel_nnls.py
@@ -2,7 +2,6 @@ import numpy as np
 from numpy import linspace, r_, exp, sqrt
 from numpy.random import seed
 from conftest import load_module
-import importlib.util
 import sys
 
 # ensure submodules are reloaded fresh for this test

--- a/tests/test_highlevel_nnls.py
+++ b/tests/test_highlevel_nnls.py
@@ -1,0 +1,58 @@
+import numpy as np
+from numpy import linspace, r_, exp, sqrt
+from numpy.random import seed
+from conftest import load_module
+import importlib.util
+import sys
+
+# ensure submodules are reloaded fresh for this test
+for name in ["pyspecdata.nnls", "pyspecdata.matrix_math.nnls", "pyspecdata.core"]:
+    sys.modules.pop(name, None)
+
+load_module("nnls")
+load_module("matrix_math.nnls")
+
+load_module("general_functions")
+core = load_module("core")
+nddata = core.nddata
+init_logging = load_module("general_functions").init_logging
+
+
+def test_highlevel_nnls():
+    seed(1234)
+    init_logging("debug")
+    vd_list = nddata(linspace(5e-4, 10, 25), "vd")
+    t1_name = r"$\\log(T_1)$"
+    logT1 = nddata(r_[-4:2:100j], t1_name)
+
+    def Gaussian_1d(axis, mu1, sigma1):
+        this_G = exp(-((axis - mu1) ** 2) / 2 / sigma1**2)
+        return this_G
+
+    true_F = Gaussian_1d(logT1.C.run(lambda x: 10 ** (x)), 6, 0.3)
+
+    K = 1.0 - 2 * exp(-vd_list / 10 ** (logT1))
+    K.reorder("vd")
+
+    M = K @ true_F
+    M.add_noise(0.2)
+    M /= 0.2
+
+    solution = M.C.nnls(
+        "vd", logT1, lambda x, y: 1 - 2 * exp(-x / 10 ** (y)), l="BRD"
+    )
+    solution_confirm = M.C.nnls(
+        "vd",
+        logT1,
+        lambda x, y: 1 - 2 * exp(-x / 10 ** (y)),
+        l=sqrt(solution.get_prop("opt_alpha")),
+    )
+
+    diff = np.linalg.norm(solution.data - solution_confirm.data)
+    assert diff < 0.2
+
+    axis_T1 = 10 ** logT1.data
+    max_T1 = axis_T1[np.argmax(solution.data)]
+    avg_T1 = np.average(axis_T1, weights=solution.data)
+    assert abs(max_T1 - 6) < 1
+    assert abs(avg_T1 - 6) < 5


### PR DESCRIPTION
## Summary
- adjust test loader to point at the compiled extension and avoid rebuilds
- retain the high-level NNLS unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c31029ca8832b996063eea6071df4