### PR TITLE
Improve wheel build workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Wheels
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'  # glob patterns only; this matches tags like v1.2.3
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel
+      - name: Build wheels
+        run: |
+          cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_TEST_COMMAND: pytest -v
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_ENVIRONMENT: FFLAGS='-fallow-argument-mismatch'
+      - name: List wheelhouse contents
+        run: ls -lh wheelhouse
+      - name: Install one built wheel for a smoke test
+        run: |
+          WHEEL=$(ls wheelhouse/*$(python -c "import sys;print(f'cp{sys.version_info.major}{sys.version_info.minor}')")*.whl | head -n 1)
+          pip install "$WHEEL"
+          python -c "import pyspecdata, sys; print('smoke test version', pyspecdata.__version__)"
+      - uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  publish:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_API_TOKEN }}
+        # To actually publish you need a secret named PYPI_API_TOKEN
+        # containing an API key from https://pypi.org/manage/account/


### PR DESCRIPTION
## Summary
- refine tag filter for GitHub Actions
- verify wheels and add smoke test install step
- clarify the note about configuring `PYPI_API_TOKEN`

## Testing
- `pytest -q`
- `flake8 pyspecdata` *(fails: many style violations)*
- `pip wheel . -w dist`

------
https://chatgpt.com/codex/tasks/task_e_687824ee91b4832b89609b2aaffd4711