### PR TITLE
Fix NNLS build with NumPy 2.0+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,12 @@ and type
 ``pip install --editable . --no-build-isolation``.
 Make sure that this terminates with a successful message, and without any compilation errors.  In particular:
 
+If you upgrade NumPy after installing ``pyspecdata``,
+any existing ``_nnls*.so`` files may be incompatible with the new version.
+Remove the old build directory (or the ``_nnls`` shared library) and reinstall
+with ``pip install --no-build-isolation --force-reinstall .`` to rebuild
+against the current NumPy headers.
+
 - If it gives an error about permissions (will happen for a system-wide anaconda install), you need to load the anaconda prompt as admin (right click and run as administrator).
 - Near the end (above EXT compiler optimization) it should tell you that you can run `pyspecdata_dataconfig`.  You should do this, unless you've installed pyspecdata before on the computer you are working at.
 

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,9 @@ project('pyspecdata', ['fortran', 'c'], version: '0.9.5.5.2', meson_version: '>=
 
 py = import('python').find_installation('python3')
 
+# Directory with compatibility headers for newer NumPy versions
+compat_inc = include_directories('nnls/compat')
+
 # Retrieve NumPy include directory
 numpy_include_dir = run_command(
   py, '-c', 'import numpy; print(numpy.get_include())'
@@ -82,7 +85,7 @@ nnls_extension = py.extension_module(
     'lapack-3.4.0/BLAS/SRC/lsame.f',
     'lapack-3.4.0/BLAS/SRC/xerbla.f',
   ],
-  include_directories: include_directories(numpy_include_dir),
+  include_directories: [include_directories(numpy_include_dir), compat_inc],
   install: true,
   cpp_args: ['-DADD_UNDERSCORE', '-I'+numpy_include_dir],  # Equivalent to define_macros=[("ADD_UNDERSCORE", None)]
   fortran_args: fortran_args,

--- a/nnls/compat/f2py_compat.h
+++ b/nnls/compat/f2py_compat.h
@@ -1,0 +1,4 @@
+#ifndef PyDataType_SET_ELSIZE
+#  define PyDataType_SET_ELSIZE(descr, size) \
+          ((descr)->elsize = (npy_intp)(size))
+#endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ authors = [
     { name = "John Franck", email = "john.franck@outlook.com" }
 ]
 
-[tool.mesonpy]
-setup-kwargs = { native_file = "cross_file.txt" }
+
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
## Summary
- remove non-existent cross_file reference
- mention how to rebuild the NNLS extension after a NumPy upgrade
- add compatibility header for missing `PyDataType_SET_ELSIZE`
- include the new header in the Meson build
- move the compatibility header into `nnls/compat`

## Testing
- `meson setup build_test`
- `pip install -e . --no-build-isolation`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688808713840832b97191969fa37e6ed