### PR TITLE
Fix loader path handling

### DIFF
--- a/nnls/venk_brd.f90
+++ b/nnls/venk_brd.f90
@@ -1,6 +1,6 @@
   subroutine venk_brd(initial_alpha,k0_mat,m,n,m_r,f,alpha_out,tol,maxiter)
     !f2py threadsafe
-    ! implement the Butler–Reeds–Dawson solver in Fortran
+    ! implement the Butler-Reeds-Dawson solver in Fortran
     integer,intent(in) :: m,n,maxiter
     double precision,intent(in) :: initial_alpha,tol
     double precision,intent(in) :: k0_mat(m,n),m_r(m)

--- a/pyspecdata/matrix_math/__init__.py
+++ b/pyspecdata/matrix_math/__init__.py
@@ -1,0 +1,6 @@
+"""Matrix math utilities."""
+
+from .nnls import venk_nnls
+
+__all__ = ["venk_nnls"]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,9 +307,17 @@ def load_module(name: str, *, use_real_pint: bool = False):
         fig_stub.figlist = type("figlist", (), {})
     os.environ.setdefault("pyspecdata_figures", "standard")
 
-    pkg = sys.modules.setdefault("pyspecdata", types.ModuleType("pyspecdata"))
-    if not hasattr(pkg, "__path__"):
-        pkg.__path__ = [str(PACKAGE_ROOT)]
+    if "pyspecdata" not in sys.modules:
+        try:
+            pkg = importlib.import_module("pyspecdata")
+        except Exception:
+            pkg = types.ModuleType("pyspecdata")
+            sys.modules["pyspecdata"] = pkg
+    else:
+        pkg = sys.modules["pyspecdata"]
+    existing_paths = list(getattr(pkg, "__path__", []))
+    if str(PACKAGE_ROOT) not in existing_paths:
+        pkg.__path__ = existing_paths + [str(PACKAGE_ROOT)]
 
     spec = importlib.util.spec_from_file_location(
         f"pyspecdata.{name}", PACKAGE_ROOT / f"{name.replace('.', '/')}.py"

--- a/tests/test_highlevel_nnls.py
+++ b/tests/test_highlevel_nnls.py
@@ -2,6 +2,9 @@ import numpy as np
 from numpy import linspace, r_, exp, sqrt
 from numpy.random import seed
 from conftest import load_module
+core = load_module("core")
+nddata = core.nddata
+init_logging = load_module("general_functions").init_logging
 from pyspecdata.matrix_math import venk_nnls
 import sys
 


### PR DESCRIPTION
## Summary
- export `venk_nnls` from `pyspecdata.matrix_math`
- ensure Fortran source uses ASCII dash
- keep installed paths in custom loader so `_nnls` extension can be found
- load modules explicitly in high level NNLS test
- import installed package in loader when available

## Testing
- `pip install -e .[tests] --no-build-isolation`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68890ac3be20832ba1ed3b9c9fa76756