### PR TITLE
Add HDF5 layout test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,8 @@ def load_module(name: str, *, use_real_pint: bool = False):
         pylab_stub.rcParams = {
             "axes.prop_cycle": types.SimpleNamespace(
                 by_key=lambda: {"color": ["k"]}
-            )
+            ),
+            "figure.figsize": (6.4, 4.8),
         }
         pylab_stub.pi = np.pi
         pylab_stub.r_ = np.r_

--- a/tests/test_hdf5_layout.py
+++ b/tests/test_hdf5_layout.py
@@ -18,42 +18,102 @@ except Exception:
 sys.modules['numpy.core.rec'] = rec
 np.core.rec = rec
 
+# try to use real matplotlib; fall back to a minimal stub
+try:  # pragma: no cover - used only when matplotlib is available
+    import matplotlib.pyplot as plt  # noqa: F401
+    import matplotlib.pylab as pylab  # noqa: F401
+    sys.modules["pylab"] = pylab
+except Exception:  # pragma: no cover
+    plt = types.ModuleType("pyplot")
+    plt.rcParams = {"figure.figsize": (6.4, 4.8)}
+
+    def _rc(*_args, **_kwargs):
+        pass
+
+    plt.rc = _rc
+    plt.gci = lambda: None
+    sys.modules.setdefault("matplotlib", types.ModuleType("matplotlib"))
+    sys.modules["matplotlib"].pyplot = plt
+    sys.modules["matplotlib.pyplot"] = plt
+    sys.modules["matplotlib.pylab"] = plt
+    _pylab = types.ModuleType("pylab")
+    _pylab.pi = np.pi
+    _pylab.r_ = np.r_
+    sys.modules["pylab"] = _pylab
+
 # load nddata using helper to avoid requiring full dependencies
 core = load_module('core', use_real_pint=True)
 nddata = core.nddata
 
 
+class DummyGroup(dict):
+    """Minimal dict subclass mimicking an h5py group/dataset.
+
+    Accessing ``attrs['key']`` simply returns ``self['key']``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.attrs = self
+
+
+def dummy_class_from_step1(obj):
+    """Recursively convert dictionaries to :class:`DummyGroup`."""
+
+    if isinstance(obj, dict):
+        return DummyGroup({k: dummy_class_from_step1(v) for k, v in obj.items()})
+    return obj
+
+
+def _generate_nddata():
+    a = nddata(np.arange(6).reshape(2, 3), ["t", "f"])
+    a.labels({"t": np.linspace(0.0, 1.0, 2), "f": np.array([10, 20, 30])})
+    a.set_units("t", "s")
+    a.set_units("f", "Hz")
+    a.set_units("V")
+    a.name("test_nd")
+    a.meta = {"level1": {"level2": 5, "level2list": [1, 2, 3]}}
+    return a
+
+
+def _check_hdf_layout(g, a):
+    assert "data" in g
+    dimlabels = [
+        x[0].decode() if isinstance(x[0], (bytes, np.bytes_)) else x[0]
+        for x in g.attrs["dimlabels"]
+    ]
+    assert dimlabels == ["t", "f"]
+
+    axes_group = g["axes"]
+    for name, coords, unit in [
+        ("t", a.getaxis("t"), "s"),
+        ("f", a.getaxis("f"), "Hz"),
+    ]:
+        assert name in axes_group
+        ds = axes_group[name]
+        np.testing.assert_allclose(ds["data"], coords)
+        axis_unit = ds.attrs["axis_coords_units"]
+        if isinstance(axis_unit, (bytes, np.bytes_)):
+            axis_unit = axis_unit.decode()
+        assert axis_unit == unit
+
+    meta = g["meta"]
+    assert "level1" in meta
+    assert meta["level1"].attrs["level2"] == 5
+    np.testing.assert_array_equal(
+        meta["level1"].attrs["level2list"]["LISTELEMENTS"], [1, 2, 3]
+    )
+
+
 def test_hdf5_layout(tmp_path):
-    a = nddata(np.arange(6).reshape(2, 3), ['t', 'f'])
-    a.labels({'t': np.linspace(0.0, 1.0, 2), 'f': np.array([10, 20, 30])})
-    a.set_units('t', 's')
-    a.set_units('f', 'Hz')
-    a.set_units('V')
-    a.name('test_nd')
-    a.meta = {'level1': {'level2': 5, 'level2list': [1, 2, 3]}}
+    a = _generate_nddata()
+    a.hdf5_write("sample.h5", directory=str(tmp_path))
+    with h5py.File(tmp_path / "sample.h5", "r") as f:
+        assert "test_nd" in f
+        _check_hdf_layout(f["test_nd"], a)
 
-    a.hdf5_write('sample.h5', directory=str(tmp_path))
 
-    with h5py.File(tmp_path / 'sample.h5', 'r') as f:
-        assert 'test_nd' in f
-        g = f['test_nd']
-        assert 'data' in g
-        dimlabels = [x[0].decode() for x in g.attrs['dimlabels']]
-        assert dimlabels == ['t', 'f']
-
-        axes_group = g['axes']
-        for name, coords, unit in [
-            ('t', a.getaxis('t'), 's'),
-            ('f', a.getaxis('f'), 'Hz'),
-        ]:
-            assert name in axes_group
-            ds = axes_group[name]
-            np.testing.assert_allclose(ds['data'], coords)
-            assert ds.attrs['axis_coords_units'].decode() == unit
-
-        meta = g['meta']
-        assert 'level1' in meta
-        assert meta['level1'].attrs['level2'] == 5
-        np.testing.assert_array_equal(
-            meta['level1'].attrs['level2list']['LISTELEMENTS'], [1, 2, 3]
-        )
+def test_hdf5_layout_from_state():
+    a = _generate_nddata()
+    g = dummy_class_from_step1(a.__getstate__())
+    _check_hdf_layout(g, a)

--- a/tests/test_hdf5_layout.py
+++ b/tests/test_hdf5_layout.py
@@ -1,0 +1,59 @@
+import sys
+import types
+
+import numpy as np
+import h5py
+import tables
+
+from conftest import load_module
+
+# ensure optional compiled dependency is stubbed
+sys.modules.setdefault('_nnls', types.ModuleType('_nnls'))
+# numpy.core.rec was removed in newer numpy, but nddata.hdf5_write expects it
+rec = types.ModuleType('rec')
+try:
+    rec.fromarrays = np.core.records.fromarrays
+except Exception:
+    rec.fromarrays = np.core.records.fromarrays
+sys.modules['numpy.core.rec'] = rec
+np.core.rec = rec
+
+# load nddata using helper to avoid requiring full dependencies
+core = load_module('core', use_real_pint=True)
+nddata = core.nddata
+
+
+def test_hdf5_layout(tmp_path):
+    a = nddata(np.arange(6).reshape(2, 3), ['t', 'f'])
+    a.labels({'t': np.linspace(0.0, 1.0, 2), 'f': np.array([10, 20, 30])})
+    a.set_units('t', 's')
+    a.set_units('f', 'Hz')
+    a.set_units('V')
+    a.name('test_nd')
+    a.meta = {'level1': {'level2': 5, 'level2list': [1, 2, 3]}}
+
+    a.hdf5_write('sample.h5', directory=str(tmp_path))
+
+    with h5py.File(tmp_path / 'sample.h5', 'r') as f:
+        assert 'test_nd' in f
+        g = f['test_nd']
+        assert 'data' in g
+        dimlabels = [x[0].decode() for x in g.attrs['dimlabels']]
+        assert dimlabels == ['t', 'f']
+
+        axes_group = g['axes']
+        for name, coords, unit in [
+            ('t', a.getaxis('t'), 's'),
+            ('f', a.getaxis('f'), 'Hz'),
+        ]:
+            assert name in axes_group
+            ds = axes_group[name]
+            np.testing.assert_allclose(ds['data'], coords)
+            assert ds.attrs['axis_coords_units'].decode() == unit
+
+        meta = g['meta']
+        assert 'level1' in meta
+        assert meta['level1'].attrs['level2'] == 5
+        np.testing.assert_array_equal(
+            meta['level1'].attrs['level2list']['LISTELEMENTS'], [1, 2, 3]
+        )


### PR DESCRIPTION
## Summary
- add test to ensure nddata.hdf5_write stores data, axis coordinates/units, and nested metadata (including list values) in expected HDF5 layout

## Testing
- `pytest tests/test_hdf5_layout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68949fc0b0e0832b85764e0bb123382a