### PR TITLE
Handle complex data and errors in HDF5 state serialization

### DIFF
--- a/tests/test_hdf5_layout.py
+++ b/tests/test_hdf5_layout.py
@@ -28,11 +28,15 @@ class DummyGroup(dict):
 
 
 def _generate_nddata():
-    a = nddata(np.arange(6).reshape(2, 3), ["t", "f"])
+    data = np.arange(6).reshape(2, 3) + 1j * np.arange(1, 7).reshape(2, 3)
+    a = nddata(data, ["t", "f"])
     a.labels({"t": np.linspace(0.0, 1.0, 2), "f": np.array([10, 20, 30])})
     a.set_units("t", "s")
     a.set_units("f", "Hz")
     a.set_units("V")
+    a.set_error(np.full(a.data.shape, 0.1))
+    a.set_error("t", np.array([0.01, 0.02]))
+    a.set_error("f", np.array([0.1, 0.2, 0.3]))
     a.name("test_nd")
     a.other_info.update({"level1": {"level2": 5, "level2list": [1, 2, 3]}})
     return a
@@ -41,25 +45,31 @@ def _generate_nddata():
 def _check_layout(g, a):
     assert "data" in g
     raw_labels = g.attrs["dimlabels"]
+    if hasattr(raw_labels, "astype"):
+        raw_labels = raw_labels.astype("S")
     dimlabels = []
     for lbl in raw_labels:
-        if not isinstance(lbl, (bytes, np.bytes_, str)) and hasattr(
-            lbl, "__getitem__"
-        ):
-            lbl = lbl[0]
         if isinstance(lbl, (bytes, np.bytes_)):
             lbl = lbl.decode("utf-8")
         dimlabels.append(lbl)
     assert dimlabels == ["t", "f"]
 
     axes_group = g["axes"]
-    for name, coords, unit in [
-        ("t", a.getaxis("t"), "s"),
-        ("f", a.getaxis("f"), "Hz"),
-    ]:
+    shape = tuple(len(axes_group[name]["data"]) for name in dimlabels)
+    data_ds = g["data"]
+    data_vals = np.array(data_ds["data"]).reshape(shape)
+    error_vals = np.array(data_ds["error"]).reshape(shape)
+    np.testing.assert_allclose(data_vals.real, a.data.real)
+    np.testing.assert_allclose(data_vals.imag, a.data.imag)
+    np.testing.assert_allclose(error_vals, a.get_error())
+
+    for name in dimlabels:
+        coords = a.getaxis(name)
+        unit = "s" if name == "t" else "Hz"
         assert name in axes_group
         ds = axes_group[name]
         np.testing.assert_allclose(ds["data"], coords)
+        np.testing.assert_allclose(ds["error"], a.get_error(name))
         axis_unit = ds.attrs["axis_coords_units"]
         if isinstance(axis_unit, (bytes, np.bytes_)):
             axis_unit = axis_unit.decode()


### PR DESCRIPTION
## Summary
- Normalize `dimlabels` attributes to flat string lists in layout checks
- Derive data shape from axis lengths in `nddata.__setstate__`

## Testing
- `pytest tests/test_hdf5_layout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68958136c2c8832ba8febfe154b32aae