### PR TITLE
pint parsing fix isolated

### DIFF
--- a/examples/ESR/esr_example.py
+++ b/examples/ESR/esr_example.py
@@ -9,37 +9,53 @@ Check out the
 example to understand how
 pySpecData locates the file here.
 """
+
 import matplotlib.pyplot as plt
 import pyspecdata as psd
+
 # %%
 # Load some 1D ESR data with harmonic + phase info.
 # The data is initial organized into two dimensions -- `harmonic` and $B_0$.
-# 
+#
 
-d = psd.find_file("S175R1a.*DHPC.*today.*200304",
-        exp_type='francklab_esr/Sam')
+d = psd.find_file(
+    "S175R1a.*DHPC.*today.*200304.*",
+    exp_type="francklab_esr/Sam",
+    zenodo="21287247",
+)
 print(d.shape)
-print("here, we see the harmonic axis contains both harmonic and phase info",repr(d.getaxis('harmonic')))
-d.chunk_auto('harmonic','phase')
+print(
+    "here, we see the harmonic axis contains both harmonic and phase info",
+    repr(d.getaxis("harmonic")),
+)
+d.chunk_auto("harmonic", "phase")
 
 # %%
-# `chunk_auto` breaks the `harmonic` dimensions since it was labeled with an axis that had 2 fields.
+# `chunk_auto` breaks the `harmonic` dimensions since it was labeled with an
+# axis that had 2 fields.
 
 print(d.shape)
 
 plt.figure(1)
-psd.plot(d['phase',0], alpha=0.5)
-psd.plot(d['phase',1], ':', alpha=0.5)
+psd.plot(d["phase", 0], alpha=0.5)
+psd.plot(d["phase", 1], ":", alpha=0.5)
 plt.title("1D Data with Multiple Harmonics")
 
 # %%
 # Next, let's load some power-saturation data
 
-d = psd.find_file("Power.*Sat.*200303",
-        exp_type='francklab_esr/Sam')
-d.chunk_auto('harmonic','phase')
+d = psd.find_file(
+    ".*Power.*Sat_200303.*",
+    exp_type="francklab_esr/Sam",
+    zenodo="21287247",
+)
+d.chunk_auto("harmonic", "phase")
 plt.figure(2)
-psd.image(d['harmonic',0]['phase',0].C.set_axis('Microwave Power','#').set_units('Microwave Power','scan #'))
+psd.image(
+    d["harmonic", 0]["phase", 0]
+    .C.set_axis("Microwave Power", "#")
+    .set_units("Microwave Power", "scan #")
+)
 plt.title("2D Power Saturation")
-plt.gca().set_aspect('auto')
+plt.gca().set_aspect("auto")
 plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "matplotlib>=3.8.0",  # sharex is a problem in 3.5-6
     "pillow",
     "pint",
+    "requests",
     "lmfit>=1.1",  # we recently found that at least 1.0.3 generates
     #                output parameters that are unchanged, but still
     #                returns a "success" condition

--- a/pyspecdata/fourier/ft_shift.py
+++ b/pyspecdata/fourier/ft_shift.py
@@ -412,7 +412,17 @@ def ft_clear_startpoints(self, axis, t=None, f=None, nearest=None):
     else:
         if t == "reset":
             t = None
-        dt = _get_ft_dt(self, axis)
+        if self.get_ft_prop(axis):
+            # axis is in frequency domain
+            N = len(self.getaxis(axis))
+            dt = (
+                (N)
+                / (N + 1)
+                / np.diff(self.getaxis(axis)[r_[0, -1]]).item()
+            )
+        else:
+            # axis in time domain
+            dt = np.diff(self.getaxis(axis)[r_[0, 1]]).item()
         orig_t = self.get_ft_prop(axis, ["start", "time"])
         if orig_t is None and not self.get_ft_prop(axis):
             orig_t = self.getaxis(axis)[0]
@@ -462,17 +472,6 @@ def _get_ft_df(self, axis):
         # axis in time domain
         N = len(self.getaxis(axis))
         return (N) / (N + 1) / np.diff(self.getaxis(axis)[r_[0, -1]]).item()
-
-
-def _get_ft_dt(self, axis):
-    if self.get_ft_prop(axis):
-        # axis is in frequency domain
-        N = len(self.getaxis(axis))
-        return (N) / (N + 1) / np.diff(self.getaxis(axis)[r_[0, -1]]).item()
-    else:
-        # axis in time domain
-        return np.diff(self.getaxis(axis)[r_[0, 1]]).item()
-
 
 def _find_index(u, origin=0.0, tolerance=1e-4, verbose=False):
     (

--- a/pyspecdata/general_functions.py
+++ b/pyspecdata/general_functions.py
@@ -11,6 +11,15 @@ import numpy as np
 import logging
 import re
 import pint
+from pint.delegates.formatter._compound_unit_helpers import (
+    localize_per,
+    prepare_compount_unit,
+)
+from pint.delegates.formatter._format_helpers import (
+    formatter,
+    pretty_fmt_exponent,
+)
+from pint.delegates.formatter.plain import PrettyFormatter
 import textwrap
 
 ureg = pint.UnitRegistry()
@@ -39,9 +48,7 @@ superscript_translation = str.maketrans(
         "⋅": ".",
     }
 )
-pretty_exponent_re = re.compile(
-    r"[⁺⁻]?[⁰¹²³⁴⁵⁶⁷⁸⁹]+(?:⋅[⁰¹²³⁴⁵⁶⁷⁸⁹]+)?"
-)
+pretty_exponent_re = re.compile(r"[⁺⁻]?[⁰¹²³⁴⁵⁶⁷⁸⁹]+(?:⋅[⁰¹²³⁴⁵⁶⁷⁸⁹]+)?")
 
 
 def _normalize_pretty_unit_string(unit_string):
@@ -62,11 +69,74 @@ def _normalize_pretty_unit_string(unit_string):
 
 
 ureg.preprocessors.append(_normalize_pretty_unit_string)
+
+
+def _use_square_root_for_half_power(terms):
+    """Display exact half powers as square roots without changing the units."""
+    for unit_name, exponent in terms:
+        if exponent == 0.5:
+            yield f"√{unit_name}", 1
+        elif exponent == -0.5:
+            yield f"√{unit_name}", -1
+        else:
+            yield unit_name, exponent
+
+
+class _SquareRootPrettyFormatter(PrettyFormatter):
+    """Pretty-print exact square-root units using the compact radical form."""
+
+    def format_unit(
+        self,
+        unit,
+        uspec="",
+        sort_func=None,
+        **babel_kwds,
+    ):
+        numerator, denominator = prepare_compount_unit(
+            unit,
+            uspec,
+            sort_func=sort_func,
+            **babel_kwds,
+            registry=self._registry,
+        )
+        numerator = _use_square_root_for_half_power(numerator)
+        denominator = _use_square_root_for_half_power(denominator)
+
+        if babel_kwds.get("locale", None):
+            length = babel_kwds.get("length") or (
+                "short" if "~" in uspec else "long"
+            )
+            division_fmt = localize_per(
+                length, babel_kwds.get("locale"), "{}/{}"
+            )
+        else:
+            division_fmt = "{}/{}"
+
+        # Work from Pint's unit/exponent pairs, not from rendered strings.  This
+        # makes W**0.5 display as √W while preserving Pint's stored W**0.5 unit,
+        # so √W*√W still simplifies to W and W**3*√W to W**3.5.
+        as_ratio = babel_kwds.get("as_ratio", True)
+        assert isinstance(as_ratio, bool)
+        return formatter(
+            numerator,
+            denominator,
+            as_ratio=as_ratio,
+            single_denominator=False,
+            product_fmt="·",
+            division_fmt=division_fmt,
+            power_fmt="{}{}",
+            parentheses_fmt="({})",
+            exp_call=pretty_fmt_exponent,
+        )
+
+
+ureg.formatter._formatters["P"] = _SquareRootPrettyFormatter(ureg)
 # Older code replaced Q_ with a custom wrapper when Pint could not parse
 # compact square-root units such as "√W".  Registering this preprocessor keeps
 # Q_ as the single Pint Quantity definition while teaching every Pint parsing
-# path -- Q_, div_units, and det_unit_prefactor -- to accept both those compact
-# square-root units and Pint's pretty display strings.
+# path -- Q_, div_units, and det_unit_prefactor -- to accept compact square-root
+# units and Pint's pretty display strings.  The local pretty formatter restores
+# the legacy √W display without making √W a separate unit.
 Q_ = ureg.Quantity
 
 
@@ -500,6 +570,7 @@ def lsafen(*string, **kwargs):
 def lsafe(*string, **kwargs):
     "Output properly escaped for latex"
     if len(string) > 1:
+
         def lsafewkargs(x):
             return lsafe(x, **kwargs)
 

--- a/pyspecdata/general_functions.py
+++ b/pyspecdata/general_functions.py
@@ -112,9 +112,9 @@ class _SquareRootPrettyFormatter(PrettyFormatter):
         else:
             division_fmt = "{}/{}"
 
-        # Work from Pint's unit/exponent pairs, not from rendered strings.  This
-        # makes W**0.5 display as √W while preserving Pint's stored W**0.5 unit,
-        # so √W*√W still simplifies to W and W**3*√W to W**3.5.
+        # Work from Pint's unit/exponent pairs, not from rendered strings.
+        # This makes W**0.5 display as √W while preserving Pint's stored
+        # W**0.5 unit, so √W*√W still simplifies to W and W**3*√W to W**3.5.
         as_ratio = babel_kwds.get("as_ratio", True)
         assert isinstance(as_ratio, bool)
         return formatter(
@@ -134,9 +134,9 @@ ureg.formatter._formatters["P"] = _SquareRootPrettyFormatter(ureg)
 # Older code replaced Q_ with a custom wrapper when Pint could not parse
 # compact square-root units such as "√W".  Registering this preprocessor keeps
 # Q_ as the single Pint Quantity definition while teaching every Pint parsing
-# path -- Q_, div_units, and det_unit_prefactor -- to accept compact square-root
-# units and Pint's pretty display strings.  The local pretty formatter restores
-# the legacy √W display without making √W a separate unit.
+# path -- Q_, div_units, and det_unit_prefactor -- to accept compact square-
+# root units and Pint's pretty display strings.  The local pretty formatter
+# restores the legacy √W display without making √W a separate unit.
 Q_ = ureg.Quantity
 
 

--- a/pyspecdata/general_functions.py
+++ b/pyspecdata/general_functions.py
@@ -346,6 +346,7 @@ else:
     print_log_info = True
 
 
+# SINGLE_USE_EXCEPTION -- exported API
 def init_logging(
     level=logging.DEBUG,
     stdout_level=logging.INFO,
@@ -419,6 +420,7 @@ def init_logging(
     return logger
 
 
+# SINGLE_USE_EXCEPTION -- exported API
 def strm(*args):
     return " ".join(map(str, args))
 
@@ -451,6 +453,7 @@ def read_binary(fp, dtype, count=None):
 exp_re = re.compile(r"(.*)e([+\-])0*([0-9]+)")
 
 
+# SINGLE_USE_EXCEPTION -- exported API
 def reformat_exp(arg):
     """reformat scientific notation in a nice latex format -- used in both pdf
     and jupyter notebooks"""
@@ -469,6 +472,7 @@ def reformat_exp(arg):
         return arg
 
 
+# SINGLE_USE_EXCEPTION -- exported API
 def complex_str(arg, fancy_format=False, format_code="%.4g"):
     "render a complex string -- leaving out imaginary if it's real"
     retval = [format_code % arg.real]
@@ -570,10 +574,7 @@ def lsafen(*string, **kwargs):
 def lsafe(*string, **kwargs):
     "Output properly escaped for latex"
     if len(string) > 1:
-
-        def lsafewkargs(x):
-            return lsafe(x, **kwargs)
-
+        lsafewkargs = lambda x: lsafe(x, **kwargs)
         return " ".join(list(map(lsafewkargs, string)))
     else:
         string = string[0]
@@ -652,6 +653,7 @@ def box_muller(length, return_complex=True):
         return (n1) * 0.5
 
 
+# SINGLE_USE_EXCEPTION -- exported API
 def dp(number, decimalplaces=2, scientific=False, max_front=3):
     """format out to a certain decimal places, potentially in scientific
     notation

--- a/pyspecdata/general_functions.py
+++ b/pyspecdata/general_functions.py
@@ -18,6 +18,55 @@ ureg.define("cycle = [cyc] = cyc")  # 'cycle' is a new dimension
 ureg.define("scan = [scan]")  # experimental count is its own dimension
 ureg.define("rad = cyc*2*pi")  # 'cycle' is a new dimension
 ureg.define("Hz = cyc / s")  # Redefine 'Hz' to be cycles per second
+
+# Pint runs preprocessors on every unit string it parses.  Precompile the
+# translation table and regex once so that accepting pretty unit labels does
+# not add avoidable overhead to repeated unit operations.
+superscript_translation = str.maketrans(
+    {
+        "⁰": "0",
+        "¹": "1",
+        "²": "2",
+        "³": "3",
+        "⁴": "4",
+        "⁵": "5",
+        "⁶": "6",
+        "⁷": "7",
+        "⁸": "8",
+        "⁹": "9",
+        "⁺": "+",
+        "⁻": "-",
+        "⋅": ".",
+    }
+)
+pretty_exponent_re = re.compile(
+    r"[⁺⁻]?[⁰¹²³⁴⁵⁶⁷⁸⁹]+(?:⋅[⁰¹²³⁴⁵⁶⁷⁸⁹]+)?"
+)
+
+
+def _normalize_pretty_unit_string(unit_string):
+    """Translate pretty Pint unit text back into parseable unit syntax."""
+    if not isinstance(unit_string, str):
+        return unit_string
+    unit_string = re.sub(r"(?<=[A-Za-z0-9_\)])√", r"*√", unit_string)
+    unit_string = re.sub(
+        r"√\s*([A-Za-z_][A-Za-z0-9_]*)",
+        r"\1**0.5",
+        unit_string,
+    )
+    unit_string = pretty_exponent_re.sub(
+        lambda match: "**" + match.group(0).translate(superscript_translation),
+        unit_string,
+    )
+    return unit_string.replace("·", "*").replace("µ", "u")
+
+
+ureg.preprocessors.append(_normalize_pretty_unit_string)
+# Older code replaced Q_ with a custom wrapper when Pint could not parse
+# compact square-root units such as "√W".  Registering this preprocessor keeps
+# Q_ as the single Pint Quantity definition while teaching every Pint parsing
+# path -- Q_, div_units, and det_unit_prefactor -- to accept both those compact
+# square-root units and Pint's pretty display strings.
 Q_ = ureg.Quantity
 
 
@@ -41,36 +90,6 @@ def nicedef(self):
 
 
 Q_.to_nice = nicedef
-try:
-    if "√" in str(Q_("√W")):
-        pass
-    else:
-        raise ValueError("not interpreting sqrt!")
-except Exception:
-    print(
-        "**Warning!** pint is the package that handles units."
-        " It does a good job with everything but square roots."
-        " Right now, you are using a hack (partial fix) that helps it"
-        " handle square roots better, and basically workds."
-        " However, you are better off"
-        " getting the the jmfranck/pint fork off of github, which"
-        " you can find at https://github.com/jmfranck/pint"
-    )
-
-    def Q_(*args):
-        if len(args) == 1:
-            b = args[0]
-            a = 1
-        elif len(args) == 2:
-            a, b = args
-        else:
-            raise ValueError("I don't know what to do with more than 2 args!")
-        m = re.match(r"(.*)√(\w+)(.*)", str(b))
-        if m:
-            g1, g2, g3 = m.groups()
-            b = g1 + f" {g2}" + "^{0.5} " + g3
-            print(b)
-        return ureg.Quantity(a, b)
 
 
 # the following is equivalent to √(μ₀/4π)
@@ -481,7 +500,9 @@ def lsafen(*string, **kwargs):
 def lsafe(*string, **kwargs):
     "Output properly escaped for latex"
     if len(string) > 1:
-        lsafewkargs = lambda x: lsafe(x, **kwargs)
+        def lsafewkargs(x):
+            return lsafe(x, **kwargs)
+
         return " ".join(list(map(lsafewkargs, string)))
     else:
         string = string[0]

--- a/pyspecdata/latexscripts.py
+++ b/pyspecdata/latexscripts.py
@@ -214,13 +214,6 @@ def grab_script_string(scriptnum_as_str):
     return script_string
 
 
-def check_image_path():
-    image_path = os.path.sep.join([os.getcwd(), "auto_figures"])
-    if not os.path.exists(image_path):
-        os.mkdir(image_path)
-    return
-
-
 def get_scripts_dir():
     script_path = os.path.sep.join([os.getcwd(), "scripts", ""])
     if not os.path.exists(script_path):
@@ -238,6 +231,7 @@ def sha_string(script):
     return "".join(["%016x" % x for x in list(hasharray)])
 
 
+# SINGLE_USE_EXCEPTION -- control-flow clarity
 def cache_output_if_needed(
     scriptnum_as_str, hashstring, showcode=False, show_error=True
 ):
@@ -385,7 +379,9 @@ def main():
     and checks whether or not it should be run if a command line argument of
     "flush" is passed, it flushes that script number from the cache
     """
-    check_image_path()
+    image_path = os.path.sep.join([os.getcwd(), "auto_figures"])
+    if not os.path.exists(image_path):
+        os.mkdir(image_path)
     if len(sys.argv) > 2:
         if sys.argv[1] == "flush":
             if len(sys.argv) == 3:

--- a/pyspecdata/load_files/bruker_nmr.py
+++ b/pyspecdata/load_files/bruker_nmr.py
@@ -1,70 +1,421 @@
-from ..core import *
-from ..general_functions import read_binary
-from ..datadir import dirformat
+from ..core import logger, nddata, r_
+from ..general_functions import (
+    CustomError,
+    lsafen,
+    process_kwargs,
+    read_binary,
+    strm,
+)
 from .open_subpath import open_subpath
-import os.path
 import re
-import struct
 import numpy as np
 from numpy import nan
 
-bruker_data = nddata # should work by inheritance but doesn't
+bruker_data = nddata  # should work by inheritance but doesn't
+
 
 def det_phcorr(v):
-    if v['DIGMOD']==1:
-        logger.debug('DIGMOD is 1')
+    if v["DIGMOD"] == 1:
+        logger.debug("DIGMOD is 1")
         # table from Matlab program from C. Hilty
-        gdparray=np.array([[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[179,201,533,709,1097,1449,2225,2929,4481,5889,8993,11809,18017,23649,36065,47329,72161,94689,144353,189409,288737],[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[184,219,384,602,852,1668,2292,3368,4616,6768,9264,13568,18560,27392,36992,55040,73856,110336,147584,220928,295040]])
-        decimarray=np.array([2,3,4,6,8,12,16,24,32,48,64,96,128,192,256,384,512,768,1024]) # the -1 is because this is an index, and copied from matlab code!!!
-        dspfvs = v['DSPFVS']
-        decim = v['DECIM']
-        if 'GRPDLY' not in list(v.keys()):
+        gdparray = np.array(
+            [
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    179,
+                    201,
+                    533,
+                    709,
+                    1097,
+                    1449,
+                    2225,
+                    2929,
+                    4481,
+                    5889,
+                    8993,
+                    11809,
+                    18017,
+                    23649,
+                    36065,
+                    47329,
+                    72161,
+                    94689,
+                    144353,
+                    189409,
+                    288737,
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                [
+                    184,
+                    219,
+                    384,
+                    602,
+                    852,
+                    1668,
+                    2292,
+                    3368,
+                    4616,
+                    6768,
+                    9264,
+                    13568,
+                    18560,
+                    27392,
+                    36992,
+                    55040,
+                    73856,
+                    110336,
+                    147584,
+                    220928,
+                    295040,
+                ],
+            ]
+        )
+        # the -1 is because this is an index, and copied from matlab code!!!
+        decimarray = np.array(
+            [
+                2,
+                3,
+                4,
+                6,
+                8,
+                12,
+                16,
+                24,
+                32,
+                48,
+                64,
+                96,
+                128,
+                192,
+                256,
+                384,
+                512,
+                768,
+                1024,
+            ]
+        )
+        dspfvs = v["DSPFVS"]
+        decim = v["DECIM"]
+        if "GRPDLY" not in list(v.keys()):
             grpdly = -1
-        grpdly = v['GRPDLY'] # later versions of topspin
+        grpdly = v["GRPDLY"]  # later versions of topspin
         if grpdly == -1:
             try:
-                retval = gdparray[dspfvs,where(decimarray==decim)[0]]//2/decim
-            except:
-                if len(where(decimarray==decim)[0]) == 0:
-                    raise CustomError("Not able to find decim",decim,"in decimarray")
-                raise CustomError('Problem returning',dspfvs,where(decimarray==decim)[0],'elements of gdparray from gdparray of size',shape(gdparray),'because decimarray is of size',shape(decimarray))
+                retval = (
+                    gdparray[dspfvs, np.where(decimarray == decim)[0]]
+                    // 2
+                    / decim
+                )
+            except Exception:
+                if len(np.where(decimarray == decim)[0]) == 0:
+                    raise CustomError(
+                        "Not able to find decim", decim, "in decimarray"
+                    )
+                raise CustomError(
+                    "Problem returning",
+                    dspfvs,
+                    np.where(decimarray == decim)[0],
+                    "elements of gdparray from gdparray of size",
+                    np.shape(gdparray),
+                    "because decimarray is of size",
+                    np.shape(decimarray),
+                )
                 retval = 0
             return retval
         else:
             return grpdly
     else:
-        logger.debug('DIGMOD is %d'%v['DIGMOD'])
-        if v['DIGMOD']==3 and 'GRPDLY' in list(v.keys()):
-            logger.debug('GRPDLY is %f'%v['GRPDLY'])
-            return v['GRPDLY']
+        logger.debug("DIGMOD is %d" % v["DIGMOD"])
+        if v["DIGMOD"] == 3 and "GRPDLY" in list(v.keys()):
+            logger.debug("GRPDLY is %f" % v["GRPDLY"])
+            return v["GRPDLY"]
         return np.array([0])
+
+
 def det_rg(a):
-    '''determine the actual voltage correction from the value of rg for a bruker NMR file'''
+    """Determine the voltage correction from the Bruker NMR ``rg`` value."""
     return a
-def match_line(line,number_re,string_re,array_re):
+
+
+def match_line(line, number_re, string_re, array_re):
     m = number_re.match(line)
     if m:
-        retval = (0,m.groups()[0],np.double(m.groups()[1]))
+        retval = (0, m.groups()[0], np.double(m.groups()[1]))
     else:
         m = string_re.match(line)
         if m:
             retstring = m.groups()[1]
-            if retstring[-1]=='>':
+            if retstring[-1] == ">":
                 retstring = retstring[:-1]
-            retval = (1,m.groups()[0],0,retstring)
+            retval = (1, m.groups()[0], 0, retstring)
         else:
             m = array_re.match(line)
             if m:
                 name = m.groups()[0]
-                thislen = (np.double(m.groups()[1]),np.double(m.groups()[2]))
+                thislen = (np.double(m.groups()[1]), np.double(m.groups()[2]))
                 thisdata = m.groups()[3]
-                retval = (2,name,thislen,thisdata)
+                retval = (2, name, thislen, thisdata)
             else:
-                retval = (3,line)
+                retval = (3, line)
     return retval
+
+
 def series(file_reference, *subpath, **kwargs):
-    """For opening Bruker ser files.  Note that the expno is included as part of the subpath.
-    
+    """Open Bruker ser files.
+
+    Note that the expno is included as part of the subpath.
+
     Parameters
     ----------
     filename:
@@ -74,174 +425,211 @@ def series(file_reference, *subpath, **kwargs):
         from the ser file storing the raw data
         (this is typically a numbered directory).
     """
-    dimname = process_kwargs([('dimname',''),
-        ],kwargs)
-    #{{{ Bruker 2D
+    dimname = process_kwargs(
+        [
+            ("dimname", ""),
+        ],
+        kwargs,
+    )
+    # {{{ Bruker 2D
     v = load_acqu(file_reference, *subpath)
-    v2 = load_acqu(file_reference, *subpath, whichdim='2')
-    td2 = int(v['TD'])
-    rg = det_rg(float(v['RG']))
-    td1 = int(v2['TD'])
-    td2_zf = int(np.ceil(td2/256.)*256) # round up to 256 points, which is how it's stored
-    fp = open_subpath(file_reference,*(subpath+('ser',)), mode='rb')
-    if int(v['BYTORDA']) == 1:
-        data = read_binary(fp, np.dtype('>i4'))
+    v2 = load_acqu(file_reference, *subpath, whichdim="2")
+    td2 = int(v["TD"])
+    rg = det_rg(float(v["RG"]))
+    td1 = int(v2["TD"])
+    # round up to 256 points, which is how it's stored
+    td2_zf = int(np.ceil(td2 / 256.0) * 256)
+    fp = open_subpath(file_reference, *(subpath + ("ser",)), mode="rb")
+    if int(v["BYTORDA"]) == 1:
+        data = read_binary(fp, np.dtype(">i4"))
     else:
-        data = read_binary(fp, np.dtype('<i4'))
+        data = read_binary(fp, np.dtype("<i4"))
     fp.close()
     data = np.complex128(data)
-    data = data[0::2]+1j*data[1::2]
+    data = data[0::2] + 1j * data[1::2]
     data /= rg
-    mydimsizes = [td1,td2_zf//2]
-    mydimnames = [dimname]+['t2']
+    mydimsizes = [td1, td2_zf // 2]
+    mydimnames = [dimname] + ["t2"]
     try:
-        data = bruker_data(data,mydimsizes,mydimnames)
-    except:
+        data = bruker_data(data, mydimsizes, mydimnames)
+    except Exception:
         size_it_should_be = np.array(mydimsizes).prod()
         if size_it_should_be > len(data):
             zero_filled_data = np.zeros(size_it_should_be)
-            zero_filled_data[0:len(data)] = data
-            data = bruker_data(zero_filled_data,mydimsizes,mydimnames)
+            zero_filled_data[0 : len(data)] = data
+            data = bruker_data(zero_filled_data, mydimsizes, mydimnames)
         else:
-            new_guess = len(data)/(td2_zf//2)
-            print(lsafen("WARNING!, chopping the length of the data to fit the specified td1 of ",td1,"points!\n(specified ",list(zip(mydimnames,mydimsizes)),' td2_zf=%d)'%td2_zf))
+            print(
+                lsafen(
+                    "WARNING!, chopping the length of the data to fit the"
+                    " specified td1 of ",
+                    td1,
+                    "points!\n(specified ",
+                    list(zip(mydimnames, mydimsizes)),
+                    " td2_zf=%d)" % td2_zf,
+                )
+            )
             data = data[0:size_it_should_be]
-            data = bruker_data(data,mydimsizes,mydimnames)
-    logger.debug(strm('data straight from nddata =',data))
-    data = data['t2',0:td2//2] # now, chop out their zero filling
-    t2axis = 1./v['SW_h']*r_[1:td2//2+1]
+            data = bruker_data(data, mydimsizes, mydimnames)
+    logger.debug(strm("data straight from nddata =", data))
+    data = data["t2", 0 : td2 // 2]  # now, chop out their zero filling
+    t2axis = 1.0 / v["SW_h"] * r_[1 : td2 // 2 + 1]
     t1axis = r_[0:td1]
-    mylabels = [t1axis]+[t2axis]
-    data.labels(mydimnames,mylabels)
-    shiftpoints = int(det_phcorr(v)) # use the canned routine to calculate the first order phase shift
-    data.set_axis('t2',lambda x: x-shiftpoints/v['SW_h'])
-    data.set_units('t2','s')
-    data.set_units('digital')
-    logger.debug("I'm about to try to load the title from: "+strm(file_reference,*subpath))
-    data.set_prop('title',
-            load_title(file_reference, *subpath))
-    SFO1 = v['SFO1']
-    BF1 = v['BF1']
-    O1 = v['O1']
-    v['TD2'] = int(v['TD'])
-    del v['TD']
+    mylabels = [t1axis] + [t2axis]
+    data.labels(mydimnames, mylabels)
+    # use the canned routine to calculate the first order phase shift
+    shiftpoints = int(det_phcorr(v))
+    data.set_axis("t2", lambda x: x - shiftpoints / v["SW_h"])
+    data.set_units("t2", "s")
+    data.set_units("digital")
+    logger.debug(
+        "I'm about to try to load the title from: "
+        + strm(file_reference, *subpath)
+    )
+    data.set_prop("title", load_title(file_reference, *subpath))
+    SFO1 = v["SFO1"]
+    BF1 = v["BF1"]
+    O1 = v["O1"]
+    v["TD2"] = int(v["TD"])
+    del v["TD"]
     v.update(v2)
-    v['TD1'] = int(v['TD'])
-    del v['TD']
-    if v['SFO1'] != SFO1:
-        # for, e.g. 2H experiments, a bad SFO1 (1H) is stored in acqu2, which we don't want
-        print("warning: ignoring second dimension SFO1, since it's probably wrong")
-        v['SFO1'] = SFO1
-        v['O1'] = O1
-        v['BF1'] = BF1
-    with open_subpath(file_reference, *(subpath+('pulseprogram',)),mode='r') as fp:
+    v["TD1"] = int(v["TD"])
+    del v["TD"]
+    if v["SFO1"] != SFO1:
+        # For, e.g. 2H experiments, a bad SFO1 (1H) is stored in acqu2,
+        # which we don't want.
+        print(
+            "warning: ignoring second dimension SFO1, since it's probably"
+            " wrong"
+        )
+        v["SFO1"] = SFO1
+        v["O1"] = O1
+        v["BF1"] = BF1
+    with open_subpath(
+        file_reference, *(subpath + ("pulseprogram",)), mode="r"
+    ) as fp:
         ppg = fp.read()
         if type(ppg) is bytes:
             ppg = ppg
-        data.set_prop('pulprog',ppg)
-    data.set_prop('acq',
-            v)
-    if isinstance(file_reference,str):
-        data.set_prop('file_reference',
-                file_reference)
+        data.set_prop("pulprog", ppg)
+    data.set_prop("acq", v)
+    if isinstance(file_reference, str):
+        data.set_prop("file_reference", file_reference)
     else:
         # if it's a zip file
-        data.set_prop('file_reference',
-                file_reference[1])
-    if open_subpath(file_reference, *(subpath +
-        ('pdata','1','procs')), test_only=True):
-        data.set_prop('proc',
-                load_jcamp(file_reference, *(subpath +
-                    ('pdata','1','procs'))))
-    if open_subpath(file_reference, *(subpath+('vdlist',)), test_only=True):
-        data.set_prop('vd',
-                load_vdlist(file_reference, *subpath))
+        data.set_prop("file_reference", file_reference[1])
+    if open_subpath(
+        file_reference, *(subpath + ("pdata", "1", "procs")), test_only=True
+    ):
+        data.set_prop(
+            "proc",
+            load_jcamp(file_reference, *(subpath + ("pdata", "1", "procs"))),
+        )
+    if open_subpath(file_reference, *(subpath + ("vdlist",)), test_only=True):
+        data.set_prop("vd", load_vdlist(file_reference, *subpath))
     else:
-        logger.info(strm("vdlist doesn't exist",file_reference,'vdlist'))
-    if open_subpath(file_reference, *(subpath+('gradient_calib',)), test_only=True):
+        logger.info(strm("vdlist doesn't exist", file_reference, "vdlist"))
+    if open_subpath(
+        file_reference, *(subpath + ("gradient_calib",)), test_only=True
+    ):
         logger.debug(strm("I found a gradient_calib file"))
-        fp = open_subpath(file_reference, *(subpath+('gradient_calib',)),mode='r')
-        data.set_prop('gradient_calib',
-                fp.read())
+        fp = open_subpath(
+            file_reference, *(subpath + ("gradient_calib",)), mode="r"
+        )
+        data.set_prop("gradient_calib", fp.read())
         fp.close()
-    if open_subpath(file_reference, *(subpath+('difflist',)), test_only=True):
-        data.set_prop('diff',
-                load_vdlist(file_reference, *subpath,
-                    **dict(name='difflist')))
+    if open_subpath(
+        file_reference, *(subpath + ("difflist",)), test_only=True
+    ):
+        data.set_prop(
+            "diff",
+            load_vdlist(file_reference, *subpath, **dict(name="difflist")),
+        )
     else:
-        logger.debug(strm("difflist doesn't exist",file_reference,'difflist'))
-    logger.debug(strm('data from bruker file =',data))
-    #}}}
+        logger.debug(
+            strm("difflist doesn't exist", file_reference, "difflist")
+        )
+    logger.debug(strm("data from bruker file =", data))
+    # }}}
     return data
+
+
 def load_1D(file_reference, *subpath, **kwargs):
     """Load 1D bruker data into a file.  Load acquisition parameters into
     property 'acq' and processing parameters *from procno 1 only* into
     'proc'
-    
-    Note that is uses the 'procs' file, which appears to contain the correct data
+
+    Note that is uses the 'procs' file, which appears to contain the correct
+    data.
     """
-    dimname = process_kwargs([('dimname','')], kwargs)
+    dimname = process_kwargs([("dimname", "")], kwargs)
     v = load_acqu(file_reference, *subpath)
-    td2 = int(v['TD'])
+    td2 = int(v["TD"])
     td1 = 1
-    td2_zf = int(np.ceil(td2/256.)*256) # round up to 256 points, which is how it's stored
-    fp = open_subpath(file_reference, *(subpath+('fid',)),mode='rb')
-    if int(v['BYTORDA']) == 1:
-        data = read_binary(fp, np.dtype('>i4'))
+    # round up to 256 points, which is how it's stored
+    td2_zf = int(np.ceil(td2 / 256.0) * 256)
+    fp = open_subpath(file_reference, *(subpath + ("fid",)), mode="rb")
+    if int(v["BYTORDA"]) == 1:
+        data = read_binary(fp, np.dtype(">i4"))
     else:
-        data = read_binary(fp, np.dtype('<i4'))
+        data = read_binary(fp, np.dtype("<i4"))
     fp.close()
     data = np.complex128(data)
-    data = data[0::2]+1j*data[1::2]
-    rg = det_rg(v['RG'])
+    data = data[0::2] + 1j * data[1::2]
+    rg = det_rg(v["RG"])
     data /= rg
-    data = bruker_data(data,[td1,td2_zf//2],[dimname,'t2'])
-    data = data['t2',0:td2//2] # now, chop out their zero filling
-    t2axis = 1./v['SW_h']*r_[1:td2//2+1]
+    data = bruker_data(data, [td1, td2_zf // 2], [dimname, "t2"])
+    data = data["t2", 0 : td2 // 2]  # now, chop out their zero filling
+    t2axis = 1.0 / v["SW_h"] * r_[1 : td2 // 2 + 1]
     t1axis = r_[1]
-    data.labels([dimname,'t2'],[t1axis,t2axis])
-    shiftpoints = int(det_phcorr(v)) # use the canned routine to calculate the second order phase shift
-    #print 'shiftpoints = ',shiftpoints
-    data.set_axis('t2',lambda x: x-shiftpoints/v['SW_h'])
-    logger.debug('yes, I called with %d shiftpoints'%shiftpoints)
-    # finally, I will probably need to add in the first order phase shift for the decimation --> just translate this
-    data.set_prop('title',
-            load_title(file_reference,*subpath))
-    data.set_prop('acq',
-            v)
-    with open_subpath(file_reference, *(subpath+('pulseprogram',)),mode='r') as fp:
+    data.labels([dimname, "t2"], [t1axis, t2axis])
+    # use the canned routine to calculate the second order phase shift
+    shiftpoints = int(det_phcorr(v))
+    # print 'shiftpoints = ',shiftpoints
+    data.set_axis("t2", lambda x: x - shiftpoints / v["SW_h"])
+    logger.debug("yes, I called with %d shiftpoints" % shiftpoints)
+    # Finally, I will probably need to add in the first order phase shift for
+    # the decimation -- just translate this.
+    data.set_prop("title", load_title(file_reference, *subpath))
+    data.set_prop("acq", v)
+    with open_subpath(
+        file_reference, *(subpath + ("pulseprogram",)), mode="r"
+    ) as fp:
         ppg = fp.read()
-        data.set_prop('pulprog',ppg)
+        data.set_prop("pulprog", ppg)
     if type(file_reference) is tuple:
-        data.set_prop('filename',
-                file_reference[1])
+        data.set_prop("filename", file_reference[1])
     else:
-        data.set_prop('filename',
-                file_reference)
-    if open_subpath(file_reference,
-            *(subpath+('pdata','1','procs')),
-            test_only=True):
-        data.set_prop('proc',
-                load_jcamp(file_reference,
-                    *(subpath+('pdata','1','procs'))))
+        data.set_prop("filename", file_reference)
+    if open_subpath(
+        file_reference, *(subpath + ("pdata", "1", "procs")), test_only=True
+    ):
+        data.set_prop(
+            "proc",
+            load_jcamp(file_reference, *(subpath + ("pdata", "1", "procs"))),
+        )
     return data
+
+
 def load_vdlist(file_reference, *subpath, **kwargs):
-    name = process_kwargs([('name','vdlist')], kwargs)
+    name = process_kwargs([("name", "vdlist")], kwargs)
     subpath += (name,)
-    print("subpath is",subpath)
-    fp = open_subpath(file_reference,*subpath)
+    print("subpath is", subpath)
+    fp = open_subpath(file_reference, *subpath)
     lines = fp.readlines()
-    if isinstance(lines[0],bytes):
+    if isinstance(lines[0], bytes):
         lines = map(lambda x: x, lines)
-    lines = list(map(lambda x: x.rstrip(),lines))
-    lines = list(map((lambda x: x.replace('m','e-3')),lines))
-    lines = list(map((lambda x: x.replace('s','')),lines))
-    lines = list(map((lambda x: x.replace('u','e-6')),lines))
-    lines = list(map(np.double,lines))
+    lines = list(map(lambda x: x.rstrip(), lines))
+    lines = list(map((lambda x: x.replace("m", "e-3")), lines))
+    lines = list(map((lambda x: x.replace("s", "")), lines))
+    lines = list(map((lambda x: x.replace("u", "e-6")), lines))
+    lines = list(map(np.double, lines))
     fp.close()
     return np.array(lines)
-def load_acqu(file_reference,*subpath,**kwargs):
-    """based on file_reference, determine the jcamp file that stores the acquisition info, and load it
+
+
+def load_acqu(file_reference, *subpath, **kwargs):
+    """Determine the jcamp file that stores the acquisition info and load it.
 
     Parameters
     ----------
@@ -250,93 +638,126 @@ def load_acqu(file_reference,*subpath,**kwargs):
     subpath:
         the subpath -- see open_subpath
     whichdim: optional string
-        Default null string -- for multi-dimensional data, there is a separate acqu file for each dimension
+        Default null string -- for multi-dimensional data, there is a separate
+        acqu file for each dimension.
     return_s: bool
-        Default True -- whether to return the parameters of the saved data, or those manipulated since then.
+        Default True -- whether to return the parameters of the saved data, or
+        those manipulated since then.
     """
-    whichdim, return_s = process_kwargs([('whichdim',''),
-        ('return_s',True)],kwargs)
+    whichdim, return_s = process_kwargs(
+        [("whichdim", ""), ("return_s", True)], kwargs
+    )
     if return_s:
-        subpath += ('acqu'+whichdim+'s',) # this is what I am initially doing, and what works with the matched filtering, etc, as is, but it's actually wrong
+        # This is what I am initially doing, and what works with the matched
+        # filtering, etc, as is, but it's actually wrong.
+        subpath += ("acqu" + whichdim + "s",)
     else:
-        subpath += ('acqu'+whichdim,) # this is actually right, but doesn't work with the matched filtering, etc.
-    return load_jcamp(file_reference,*subpath)
-def load_jcamp(file_reference,*subpath):
+        # This is actually right, but doesn't work with the matched filtering,
+        # etc.
+        subpath += ("acqu" + whichdim,)
+    return load_jcamp(file_reference, *subpath)
+
+
+def load_jcamp(file_reference, *subpath):
     "return a dictionary with information for a jcamp file"
+
     def convert_to_num(val):
-        if val == '<>':
+        if val == "<>":
             return nan
-        elif val[0] == '<' and val[-1] == '>':
+        elif val[0] == "<" and val[-1] == ">":
             return val[1:-1]
-        elif '.' in val:
+        elif "." in val:
             return np.double(val)
-        elif 'e-' in val.lower():
+        elif "e-" in val.lower():
             return np.double(val)
         else:
             return int(val)
-    fp = open_subpath(file_reference,*subpath)
+
+    fp = open_subpath(file_reference, *subpath)
     lines = fp.readlines()
-    if isinstance(lines[0],bytes):
+    if isinstance(lines[0], bytes):
         lines = map(lambda x: x, lines)
     vars = {}
-    number_re = re.compile(r'##\$([_A-Za-z0-9]+) *= *([0-9\-\.]+)')
-    string_re = re.compile(r'##\$([_A-Za-z0-9]+) *= *<(.*)')
-    array_re = re.compile(r'##\$([_A-Za-z0-9]+) *= *\(([0-9]+)\.\.([0-9]+)\)(.*)')
-    lines = list(map(lambda x: x.rstrip(),lines))
-    j=0
-    retval =  match_line(lines[j],number_re,string_re,array_re)
-    j = j+1
-    retval2 =  match_line(lines[j],number_re,string_re,array_re) #always grab the second line
+    number_re = re.compile(r"##\$([_A-Za-z0-9]+) *= *([0-9\-\.]+)")
+    string_re = re.compile(r"##\$([_A-Za-z0-9]+) *= *<(.*)")
+    array_re = re.compile(
+        r"##\$([_A-Za-z0-9]+) *= *\(([0-9]+)\.\.([0-9]+)\)(.*)"
+    )
+    lines = list(map(lambda x: x.rstrip(), lines))
+    j = 0
+    retval = match_line(lines[j], number_re, string_re, array_re)
+    j = j + 1
+    # always grab the second line
+    retval2 = match_line(lines[j], number_re, string_re, array_re)
     while j < len(lines):
         isdata = False
-        if retval[0]==1 or retval[0]==2:
+        if retval[0] == 1 or retval[0] == 2:
             name = retval[1]
             thislen = retval[2]
             data = retval[3]
-            while (retval2[0] == 3) and (j<len(lines)): # eat up the following lines
-                data += ' '+retval2[1]
-                j = j+1
-                retval2 =  match_line(lines[j],number_re,string_re,array_re)
+            while (retval2[0] == 3) and (
+                j < len(lines)
+            ):  # eat up the following lines
+                data += " " + retval2[1]
+                j = j + 1
+                retval2 = match_line(lines[j], number_re, string_re, array_re)
             isdata = True
-        elif retval[0]==0:
+        elif retval[0] == 0:
             name = retval[1]
             data = retval[2]
             isdata = True
-        #else:
+        # else:
         #   print 'not a data line:',retval[1]
-        if(isdata):
-            if retval[0]==2: #if it's an array
-                data = data.split(' ')
-                if len(data)>0:
-                    while '' in data:
-                        data.remove('')
-                    data = list(map(convert_to_num,data))
-                    if len(data)-1!= thislen[1]:
-                        print('error:',len(data)-1,'!=',thislen[1])
-            vars.update({name:data})
-        # at this point, the string or array data is loaded into data and we have something in retval2 which is definitely a new line
+        if isdata:
+            if retval[0] == 2:  # if it's an array
+                data = data.split(" ")
+                if len(data) > 0:
+                    while "" in data:
+                        data.remove("")
+                    data = list(map(convert_to_num, data))
+                    if len(data) - 1 != thislen[1]:
+                        print("error:", len(data) - 1, "!=", thislen[1])
+            vars.update({name: data})
+        # At this point, the string or array data is loaded into data and we
+        # have something in retval2 which is definitely a new line.
         retval = retval2
-        j = j+1
-        if j<len(lines):
+        j = j + 1
+        if j < len(lines):
             try:
-                retval2 =  match_line(lines[j],number_re,string_re,array_re)
-            except:
-                raise RuntimeError(strm('matching line "',lines[j],'"',"in file",file_reference))
+                retval2 = match_line(lines[j], number_re, string_re, array_re)
+            except Exception:
+                raise RuntimeError(
+                    strm(
+                        'matching line "',
+                        lines[j],
+                        '"',
+                        "in file",
+                        file_reference,
+                    )
+                )
     fp.close()
     return vars
-def load_title(file_reference,*subpath):
-    logger.debug("I'm attempting to load the subpath with the following arguments: "+strm(
-        file_reference,subpath,'pdata','1','title'))
-    if not open_subpath(file_reference,*(subpath + ('pdata','1','title')), test_only=True):
+
+
+def load_title(file_reference, *subpath):
+    logger.debug(
+        "I'm attempting to load the subpath with the following arguments: "
+        + strm(file_reference, subpath, "pdata", "1", "title")
+    )
+    if not open_subpath(
+        file_reference, *(subpath + ("pdata", "1", "title")), test_only=True
+    ):
         return None
     else:
-        fp = open_subpath(file_reference,*(subpath + ('pdata','1','title')))
+        fp = open_subpath(file_reference, *(subpath + ("pdata", "1", "title")))
         lines = fp.readlines()
-        logger.debug("I get %d lines"%len(lines))
+        logger.debug("I get %d lines" % len(lines))
         if len(lines) == 0:
             lines = []
-            logger.warning("You do not have a title set -- this is highly unusual!!")
+            logger.warning(
+                "You do not have a title set -- this is highly unusual!!"
+            )
         else:
-            lines = [j for j in lines if j not in ['\r\n','\n']]
+            lines = [j for j in lines if j not in ["\r\n", "\n"]]
         fp.close()
-        return ''.join(lines)
+        return "".join(lines)

--- a/pyspecdata/load_files/load_cary.py
+++ b/pyspecdata/load_files/load_cary.py
@@ -11,6 +11,7 @@ from ..core import nddata
 import os, logging
 
 
+# SINGLE_USE_EXCEPTION -- control-flow clarity
 def load_bindata(fp, param):
     x_mode_rep = "nm;Å;cm-1;°".split(";")
     y_mode_rep = (
@@ -53,6 +54,7 @@ def load_bindata(fp, param):
     return retval
 
 
+# SINGLE_USE_EXCEPTION -- control-flow clarity
 def load_header(fp, param):
     retval = np.fromfile(
         fp,

--- a/pyspecdata/plot_funcs/DCCT_function.py
+++ b/pyspecdata/plot_funcs/DCCT_function.py
@@ -207,6 +207,7 @@ def place_labels(
         label_placed[this_label_num] = 1
 
 
+# SINGLE_USE_EXCEPTION -- exported API
 def DCCT(
     this_nddata,
     fig=None,

--- a/tests/test_axis_assignment.py
+++ b/tests/test_axis_assignment.py
@@ -4,8 +4,7 @@ from conftest import load_module
 
 load_module("general_functions")
 load_module("ndshape")
-core = load_module("core")
-nddata = core.nddata
+nddata = load_module("core").nddata
 
 
 def build_axis_test_data():

--- a/tests/test_dcct.py
+++ b/tests/test_dcct.py
@@ -2,14 +2,13 @@ from collections import OrderedDict
 import sys
 import types
 
-import matplotlib
-
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import sympy as s
 
 from conftest import load_module
+
+plt.switch_backend("Agg")
 
 sys.modules.setdefault("_nnls", types.ModuleType("_nnls"))
 

--- a/tests/test_highlevel_nnls.py
+++ b/tests/test_highlevel_nnls.py
@@ -6,18 +6,6 @@ from numpy import linspace, r_, exp, sqrt
 from numpy.random import seed
 
 
-def _load_real_pyspecdata_modules():
-    """Reload the installed package so `_nnls` stubs from other tests don't
-    leak in."""
-    sys.modules.pop("_nnls", None)
-    for name in list(sys.modules):
-        if name == "pyspecdata" or name.startswith("pyspecdata."):
-            sys.modules.pop(name, None)
-    core = importlib.import_module("pyspecdata.core")
-    matrix_math = importlib.import_module("pyspecdata.matrix_math")
-    general_functions = importlib.import_module("pyspecdata.general_functions")
-    return core, matrix_math.venk_nnls, general_functions.init_logging
-
 # ensure submodules are reloaded fresh for this test
 mu1 = 0.5
 sigma1 = 0.3
@@ -25,7 +13,17 @@ sigma1 = 0.3
 
 def test_highlevel_nnls():
     seed(1234)
-    core, venk_nnls, init_logging = _load_real_pyspecdata_modules()
+    # Reload the installed package so `_nnls` stubs from other tests don't leak
+    # in.
+    sys.modules.pop("_nnls", None)
+    for name in list(sys.modules):
+        if name == "pyspecdata" or name.startswith("pyspecdata."):
+            sys.modules.pop(name, None)
+    core = importlib.import_module("pyspecdata.core")
+    matrix_math = importlib.import_module("pyspecdata.matrix_math")
+    init_logging = importlib.import_module(
+        "pyspecdata.general_functions"
+    ).init_logging
     nddata = core.nddata
     init_logging("debug")
     vd_list = nddata(linspace(5e-4, 10, 25), "vd")
@@ -62,7 +60,7 @@ def test_highlevel_nnls():
         logT1,
         lambda x, y: 1 - 2 * exp(-x / 10 ** (y)),
         l=sqrt(solution.get_prop("opt_alpha")),
-        method=venk_nnls,
+        method=matrix_math.venk_nnls,
     )
     diff = np.linalg.norm(solution_stackcalc.data - solution_venk.data)
     assert diff < 0.054 * np.linalg.norm(

--- a/tests/test_mean_structured.py
+++ b/tests/test_mean_structured.py
@@ -3,8 +3,7 @@ from conftest import load_module
 
 load_module("general_functions")
 load_module("ndshape")
-core = load_module("core")
-nddata = core.nddata
+nddata = load_module("core").nddata
 
 
 def test_mean_structured_sets_std_per_field():

--- a/tests/test_nddata_str.py
+++ b/tests/test_nddata_str.py
@@ -36,6 +36,7 @@ def build_0d_structured_with_error():
     return x
 
 
+# SINGLE_USE_EXCEPTION -- test patch point
 def build_1d_plain():
     x = nddata(np.array([1.0, 2.0, 3.0]), "t")
     x.setaxis("t", np.array([0.0, 1.0, 2.0]))
@@ -49,6 +50,7 @@ def build_1d_plain_with_errors():
     return x
 
 
+# SINGLE_USE_EXCEPTION -- test patch point
 def build_1d_structured_data():
     data = np.zeros(3, dtype=[("a", "f8"), ("b", "f8")])
     data["a"] = [1.0, 2.0, 3.0]
@@ -68,6 +70,7 @@ def build_1d_structured_data_with_errors():
     return x
 
 
+# SINGLE_USE_EXCEPTION -- test patch point
 def build_1d_structured_axis():
     x = nddata(np.array([1.0, 2.0, 3.0]), "t")
     axis = np.zeros(3, dtype=[("f", "f8"), ("p", "f8")])

--- a/tests/test_nddata_str.py
+++ b/tests/test_nddata_str.py
@@ -4,8 +4,7 @@ from conftest import load_module
 
 load_module("general_functions")
 load_module("ndshape")
-core = load_module("core")
-nddata = core.nddata
+nddata = load_module("core").nddata
 
 
 def build_0d_plain():

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -40,6 +40,26 @@ def test_scan_unit_is_registered():
     assert quantity.check(gf.Q_(1, "cyc") / gf.Q_(1, "scan"))
 
 
+def test_compact_square_root_unit_is_parseable():
+    assert gf.Q_(1, "s√W").check(gf.Q_(1, "s * W**0.5"))
+
+
+def test_pretty_unit_string_is_parseable():
+    pretty = gf.Q_(1, "g⁰⋅⁵·µm/s⁰⋅⁵")
+    parseable = gf.Q_(1, "g**0.5 * um / s**0.5")
+    assert pretty.check(parseable)
+    assert gf.det_unit_prefactor("g⁰⋅⁵·µm/s⁰⋅⁵") == -9
+
+
+def test_div_units_accepts_pretty_unit_labels():
+    d = nddata(np.ones(2), "beta")
+    d.setaxis("beta", np.r_[0:2])
+    d.set_units("beta", "g⁰⋅⁵·µm/s⁰⋅⁵")
+    assert np.isclose(
+        d.div_units("beta", "s * W**0.5"), np.sqrt(1e-3) * 1e-6
+    )
+
+
 def test_inverse_fourier_transform_accepts_cycles_per_scan_units():
     d = nddata(np.ones(8), "temp")
     d.set_axis("temp", np.linspace(-0.5, 0.5, 8, endpoint=False))

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -43,11 +43,13 @@ def test_scan_unit_is_registered():
 def test_compact_square_root_unit_is_parseable():
     assert gf.Q_(1, "s√W").check(gf.Q_(1, "s * W**0.5"))
 
+
 def test_pretty_unit_string_is_parseable():
     pretty = gf.Q_(1, "g⁰⋅⁵·µm/s⁰⋅⁵")
     parseable = gf.Q_(1, "g**0.5 * um / s**0.5")
     assert pretty.check(parseable)
     assert gf.det_unit_prefactor("g⁰⋅⁵·µm/s⁰⋅⁵") == -9
+
 
 def test_div_units_accepts_pretty_unit_labels():
     d = nddata(np.ones(2), "beta")
@@ -55,8 +57,19 @@ def test_div_units_accepts_pretty_unit_labels():
     d.set_units("beta", "g⁰⋅⁵·µm/s⁰⋅⁵")
     assert np.isclose(d.div_units("beta", "s * W**0.5"), np.sqrt(1e-3) * 1e-6)
 
+
 def test_sqrt_formatting():
     assert "{:~P}".format(gf.Q_("W**(0.5)")) == "1.0 √W"
+
+
+def test_compact_square_root_unit_matches_half_power_unit():
+    assert gf.Q_("√W").check(gf.Q_("W**0.5"))
+
+
+def test_compact_square_root_unit_uses_normal_unit_algebra():
+    assert (gf.Q_("√W") * gf.Q_("√W")).to("W").magnitude == 1
+    assert (gf.Q_("W**3") * gf.Q_("√W")).check(gf.Q_("W**3.5"))
+
 
 def test_inverse_fourier_transform_accepts_cycles_per_scan_units():
     d = nddata(np.ones(8), "temp")

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -14,8 +14,7 @@ if getattr(pint, "__pyspec_stub__", False):
 
 # Load dependencies via the test loader (ensures real Pint is imported)
 gf = load_module("general_functions", use_real_pint=True)
-core = load_module("core", use_real_pint=True)
-nddata = core.nddata
+nddata = load_module("core", use_real_pint=True).nddata
 
 
 def test_voltage_times_current_yields_power_units():

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -43,22 +43,20 @@ def test_scan_unit_is_registered():
 def test_compact_square_root_unit_is_parseable():
     assert gf.Q_(1, "s√W").check(gf.Q_(1, "s * W**0.5"))
 
-
 def test_pretty_unit_string_is_parseable():
     pretty = gf.Q_(1, "g⁰⋅⁵·µm/s⁰⋅⁵")
     parseable = gf.Q_(1, "g**0.5 * um / s**0.5")
     assert pretty.check(parseable)
     assert gf.det_unit_prefactor("g⁰⋅⁵·µm/s⁰⋅⁵") == -9
 
-
 def test_div_units_accepts_pretty_unit_labels():
     d = nddata(np.ones(2), "beta")
     d.setaxis("beta", np.r_[0:2])
     d.set_units("beta", "g⁰⋅⁵·µm/s⁰⋅⁵")
-    assert np.isclose(
-        d.div_units("beta", "s * W**0.5"), np.sqrt(1e-3) * 1e-6
-    )
+    assert np.isclose(d.div_units("beta", "s * W**0.5"), np.sqrt(1e-3) * 1e-6)
 
+def test_sqrt_formatting():
+    assert "{:~P}".format(gf.Q_("W**(0.5)")) == "1.0 √W"
 
 def test_inverse_fourier_transform_accepts_cycles_per_scan_units():
     d = nddata(np.ones(8), "temp")


### PR DESCRIPTION
- **allow string for mean all but**
- **stupid codex approach**
- **Adding new mean method with np.view, printing 0D structure array**
- **hopefully before requesting codex changes**
- **autofilling exp type**
- **reviewd**
- **flake happy**
- **nddata str**
- **solving numpy float error**
- **only promoting changed dtypes and adding test**
- **fixing future numpy compatibility warning**
- **removing temp.py**
- **tweak some lmfit stuff**
- **JF review**
- **almost passing tests**
- **passes tests**
- **get codex to fix the broken test (broken by stubbing)**
- **flake happy**
- **basic cleanup**
- **flake happy**
- **first round of codex on improved axis/error setting**
- **fix for better translation fromstring**
- **small codex tweak to test**
- **solve jacobian shape issue**
- **working on lorentzian basis**
- **clean up and mark with TODOs**
- **fighting with codex over lorentzian basis**
- **commit some tweaks**
- **this version runs**
- **manual cleanup of lorentzian**
- **move lorentzian lars to procscripts**
- **Correcting lmfitdata**
- **Codex jacobian**
- **JF edit**
- **add warning**
- **codex draft w/ my todos added**
- **tweak**
- **restore use_jacobian, which was deleted for some reason**
- **fix to lmfitdata**
- **unrelated doc tweak**
- **fix tests**
- **flake happy**
- **add mechanism for exceptions**
- **clean up stylistic stuff**
- **Adding pint preprocessing**
- **test for what I really care about**
- **Fighting with codex to get square root formatting**
- **flake**
- **single use definitions**
